### PR TITLE
Spa with removed elements

### DIFF
--- a/home.inc.php
+++ b/home.inc.php
@@ -507,7 +507,9 @@ if (is_null($next_to_last_login)) {
       document.write('\x3Cscript src="extensions.js" type="text/javascript">\x3C/script>');
       document.write('\x3Cscript src="messagebox.js" type="text/javascript">\x3C/script>');
       document.write('\x3Cscript src="scripts.js" type="text/javascript">\x3C/script>');
-
+    
+      // single page appcliation script
+      document.write('\x3Cscript src="single-page-application.js" type="text/javascript">\x3C/script>');
 
       // include scripts for every single page
       document.write('\x3Cscript src="home/home.js" type="text/javascript">\x3C/script>');
@@ -515,9 +517,6 @@ if (is_null($next_to_last_login)) {
       document.write('\x3Cscript src="home/query.js" type="text/javascript">\x3C/script>');
       document.write('\x3Cscript src="home/user.js" type="text/javascript">\x3C/script>');
       document.write('\x3Cscript src="home/settings.js" type="text/javascript">\x3C/script>');
-    
-      // single page appcliation script
-      document.write('\x3Cscript src="single-page-application.js" type="text/javascript">\x3C/script>');
     </script>
     
   </body>

--- a/home/home.js
+++ b/home/home.js
@@ -1,6 +1,6 @@
 // feed
 
-var $feed = $('#feed'), 
+var $feed = $(page['home']).find('#feed'), 
     noFeedContent = '<p>Nothing new since last login.</p>',
     feedSince = -1; // since last login
 
@@ -62,11 +62,11 @@ function refreshFeed(showLoadingInformation, callback) {
 }
 
 // button load whole feed event listener
-$('#feed-load-all').on('click', function() {
-  $('#feed-load-all').prop('disabled', true).attr('value', 'Loading all...');
+$(page['home']).find('#feed-load-all').on('click', function() {
+  $(page['home']).find('#feed-load-all').prop('disabled', true).attr('value', 'Loading all...');
   feedSince = 0;
   refreshFeed(false, function() {
-    $('#feed-load-all').hide();
+    $(page['home']).find('#feed-load-all').hide();
   });
 });
 
@@ -74,7 +74,7 @@ $('#feed-load-all').on('click', function() {
 
 // recently used
 
-var $recentlyUsed = $('#recently-used'), noRecentlyUsed = '<p>No recently used lists found.</p>';
+var $recentlyUsed = $(page['home']).find('#recently-used'), noRecentlyUsed = '<p>No recently used lists found.</p>';
 
 function refreshRecentlyUsed(showLoadingInformation) {
   if (showLoadingInformation) 

--- a/home/query.js
+++ b/home/query.js
@@ -206,7 +206,7 @@ var querySelectedLists = [];
 // get label list of user
 function refreshQueryLabelList(showLoadingInformation) {
   if (showLoadingInformation) {
-    $('#query-selection').html(loading);
+    $(page['query']).find('#query-selection').html(loading);
   }
 
   // send request
@@ -245,20 +245,20 @@ function refreshQueryLabelList(showLoadingInformation) {
       );
     }
 
-    $('#query-selection').html('<p><input id="query-start-button" type="button" value="Start test" class="width-100 height-50px font-size-20px" disabled="true"/></p><div id="query-label-selection"></div><div id="query-list-selection"></div><br class="clear-both">');
+    $(page['query']).find('#query-selection').html('<p><input id="query-start-button" type="button" value="Start test" class="width-100 height-50px font-size-20px" disabled="true"/></p><div id="query-label-selection"></div><div id="query-list-selection"></div><br class="clear-both">');
 
     // provide label selection
-    $('#query-label-selection').html(getHtmlTableOfLabelsQuery(queryLabels));
+    $(page['query']).find('#query-label-selection').html(getHtmlTableOfLabelsQuery(queryLabels));
 
     // provide list selection
     refreshQueryListSelection();
 
 
     // start query button click event
-    $('#query-start-button').on('click', startQuery);
+    $(page['query']).find('#query-start-button').on('click', startQuery);
 
     // checkbox click event
-    $('#query-label-selection tr').on('click', function(){
+    $(page['query']).find('#query-label-selection tr').on('click', function(){
       // read label id from checkbox data tag
       var labelId = $(this).data('query-label-id');
       // checkbox has been unchecked
@@ -273,7 +273,7 @@ function refreshQueryLabelList(showLoadingInformation) {
 
     // expand functionallity
     // expand single labels
-    $('#query-label-selection .small-exp-col-icon').on('click', function(e) {
+    $(page['query']).find('#query-label-selection .small-exp-col-icon').on('click', function(e) {
       e.stopPropagation();
       var $this = $(this);
       var expand = ($this.data('state') == 'collapsed');
@@ -322,10 +322,10 @@ function refreshQueryListSelection() {
   }
 
 
-  $('#query-list-selection').html('<table class="box-table cursor-pointer no-flex"><tr class="cursor-default"><th colspan="2">Lists</th></tr>' + html + '</table');
+  $(page['query']).find('#query-list-selection').html('<table class="box-table cursor-pointer no-flex"><tr class="cursor-default"><th colspan="2">Lists</th></tr>' + html + '</table');
 
   // checkbox click event
-  $('#query-list-selection tr').on('click', function(){
+  $(page['query']).find('#query-list-selection tr').on('click', function(){
     // read list id from checkbox data tag
     var listId = $(this).data('query-list-id');
     
@@ -348,7 +348,7 @@ function addLabelToQuery(labelId) {
     }
   }
 
-  $('#query-label-selection tr[data-query-label-id=' + labelId + ']').addClass('active').data('checked', true);
+  $(page['query']).find('#query-label-selection tr[data-query-label-id=' + labelId + ']').addClass('active').data('checked', true);
   querySelectedLabel.push(labelId);
 }
 
@@ -359,13 +359,13 @@ function removeLabelFromQuery(labelId) {
       removeListFromQuery(queryAttachments[i].list);
     }
   }
-  $('#query-label-selection tr[data-query-label-id=' + labelId + ']').removeClass('active').data('checked', false);
+  $(page['query']).find('#query-label-selection tr[data-query-label-id=' + labelId + ']').removeClass('active').data('checked', false);
   querySelectedLabel.removeAll(labelId);
 }
 
 function addListToQuery(listId) {
   querySelectedLists.push(getListById(listId));
-  $('#query-list-selection tr[data-query-list-id=' + listId + ']').data('checked', true).addClass('active');
+  $(page['query']).find('#query-list-selection tr[data-query-list-id=' + listId + ']').data('checked', true).addClass('active');
   checkStartQueryButtonEnable();
 
   // update information about the language of the selected words
@@ -374,7 +374,7 @@ function addListToQuery(listId) {
 
 function removeListFromQuery(listId) {
   querySelectedLists.removeAll(getListById(listId));
-  $('#query-list-selection tr[data-query-list-id=' + listId + ']').data('checked', false).removeClass('active');
+  $(page['query']).find('#query-list-selection tr[data-query-list-id=' + listId + ']').data('checked', false).removeClass('active');
   checkStartQueryButtonEnable();
 
   // update information about the language of the selected words
@@ -386,7 +386,7 @@ function getListRow(list, selected) {
 }
 
 function checkStartQueryButtonEnable() {
-  $('#query-start-button').prop('disabled', querySelectedLists.length === 0);
+  $(page['query']).find('#query-start-button').prop('disabled', querySelectedLists.length === 0);
 }
 
 function compareListsByName(a, b) {
@@ -464,8 +464,8 @@ var queryWords = [], // array of all words which the user selected for the query
     
     
 function startQuery() {
-  $('#query-not-started-info').addClass('display-none');
-  $('#query-content-table').removeClass('display-none');
+  $(page['query']).find('#query-not-started-info').addClass('display-none');
+  $(page['query']).find('#query-content-table').removeClass('display-none');
   queryRunning = true;
 
   // produce one array containing all query words
@@ -489,8 +489,8 @@ function startQuery() {
 
   nextWord();
 
-  //$('#query-select-box img[data-action="collapse"]').trigger('collapse');
-  $('#query-box img[data-action="expand"]').trigger('expand'); // expand query container
+  //$(page['query']).find('#query-select-box img[data-action="collapse"]').trigger('collapse');
+  $(page['query']).find('#query-box img[data-action="expand"]').trigger('expand'); // expand query container
 
 }
 
@@ -499,12 +499,12 @@ function nextWord() {
   
   queryWrongAnswerGiven = false;
   
-  $('#query-answer-not-known').prop('disabled', false);
-  $('#query-answer-known').attr('value', 'I know!');
-  $('#query-answer-not-known').attr('value', 'No idea.');
-  $('#query-answer-buttons').hide();
-  $('#correct-answer').hide();
-  $('#query-answer-not-sure').prop('disabled', false);
+  $(page['query']).find('#query-answer-not-known').prop('disabled', false);
+  $(page['query']).find('#query-answer-known').attr('value', 'I know!');
+  $(page['query']).find('#query-answer-not-known').attr('value', 'No idea.');
+  $(page['query']).find('#query-answer-buttons').hide();
+  $(page['query']).find('#correct-answer').hide();
+  $(page['query']).find('#query-answer-not-sure').prop('disabled', false);
 
   
   currentWord = getNextWord();
@@ -519,22 +519,22 @@ function nextWord() {
 
   // fill the question fields
   if (queryCurrentDirection == QueryDirection.Ltr) {
-    $('#query-lang1').html(listOfTheWord.language1);
-    $('#query-lang2').html(listOfTheWord.language2);
-    $('#query-question').html(currentWord.language1);
+    $(page['query']).find('#query-lang1').html(listOfTheWord.language1);
+    $(page['query']).find('#query-lang2').html(listOfTheWord.language2);
+    $(page['query']).find('#query-question').html(currentWord.language1);
     currentWordCorrectAnswer = currentWord.language2;
   }
   else if (queryCurrentDirection == QueryDirection.Rtl) {
-    $('#query-lang1').html(listOfTheWord.language2);
-    $('#query-lang2').html(listOfTheWord.language1);
-    $('#query-question').html(currentWord.language2);
+    $(page['query']).find('#query-lang1').html(listOfTheWord.language2);
+    $(page['query']).find('#query-lang2').html(listOfTheWord.language1);
+    $(page['query']).find('#query-question').html(currentWord.language2);
     currentWordCorrectAnswer = currentWord.language1;
   }
   
-  $('#query-answer').val('').focus();
+  $(page['query']).find('#query-answer').val('').focus();
 
   // known average for single word information
-  $('#query-word-mark').html(Math.round(currentWord.getKnownAverage() * 100) + "%");
+  $(page['query']).find('#query-word-mark').html(Math.round(currentWord.getKnownAverage() * 100) + "%");
 }
 
 function getNextWord() {
@@ -552,7 +552,7 @@ function getNextWord() {
 }
 
 // allow enter pressing to check the user's answer
-$('#query-answer').on('keypress', function(e) {
+$(page['query']).find('#query-answer').on('keypress', function(e) {
   if (e.which == 13) {
     if (checkAnswer($(this).val(), currentWordCorrectAnswer)) { // correct answer  
       if (queryCurrentAnswerState == QueryAnswerState.NotKnown || queryCurrentAnswerState == QueryAnswerState.NotSureClicked || queryCurrentAnswerState == QueryAnswerState.WaitToContinue) {
@@ -589,14 +589,14 @@ function checkAnswer(user, correct) {
 
 function refreshQueryResultsUploadButton() {
   var notUploadedAnswersCount = queryAnswers.length - nextIndexToUpload;
-  $('#query-results-upload-button').prop('disabled', !(notUploadedAnswersCount > 0)).attr('value', 'Upload ' + ((notUploadedAnswersCount > 0)? notUploadedAnswersCount + ' ' : '') + 'answer' + ((notUploadedAnswersCount == 1) ? '' : 's'));
+  $(page['query']).find('#query-results-upload-button').prop('disabled', !(notUploadedAnswersCount > 0)).attr('value', 'Upload ' + ((notUploadedAnswersCount > 0)? notUploadedAnswersCount + ' ' : '') + 'answer' + ((notUploadedAnswersCount == 1) ? '' : 's'));
 }
 
 function refreshQueryResultsUploadCounter() {
-  $('#query-results-upload-counter').html('Uploaded ' + nextIndexToUpload + '/' + queryAnswers.length + ' test answers.');
+  $(page['query']).find('#query-results-upload-counter').html('Uploaded ' + nextIndexToUpload + '/' + queryAnswers.length + ' test answers.');
 }
 
-$('#query-results-upload-button').on('click', uploadQueryResults);
+$(page['query']).find('#query-results-upload-button').on('click', uploadQueryResults);
 
 
 // upload query results
@@ -632,7 +632,7 @@ function uploadQueryResults() {
 
 
 // query answer buttons events (know, not sure, don't know)
-$('#query-answer-known').on('click', function() {
+$(page['query']).find('#query-answer-known').on('click', function() {
   // known button click event
   if (queryCurrentAnswerState == QueryAnswerState.WaitToContinue || queryCurrentAnswerState == QueryAnswerState.NotKnown) {
     nextWord();
@@ -642,12 +642,12 @@ $('#query-answer-known').on('click', function() {
     processQueryCurrentAnswerState();
   }
 });
-$('#query-answer-not-sure').on('click', function() {
+$(page['query']).find('#query-answer-not-sure').on('click', function() {
   // not sure button click event
   queryCurrentAnswerState = QueryAnswerState.NotSureClicked;
   processQueryCurrentAnswerState();
 });
-$('#query-answer-not-known').on('click', function() {
+$(page['query']).find('#query-answer-not-known').on('click', function() {
   // not known button click event
   queryCurrentAnswerState = QueryAnswerState.NotKnownClicked;
   processQueryCurrentAnswerState();
@@ -658,25 +658,25 @@ function processQueryCurrentAnswerState() {
     case queryCurrentAnswerState.Start:
       return;
     case QueryAnswerState.Known:
-      $('#query-box').trigger('shadow-blink-green');
+      $(page['query']).find('#query-box').trigger('shadow-blink-green');
       addQueryAnswer(currentWord, 1);
       tryAutoUpload();
       nextWord();
       return;
     case QueryAnswerState.NotSureClicked:
-      $('#query-answer-not-sure').prop('disabled', true);
-      $('#query-answer-known').attr('value', 'I knew that!');
-      $('#query-answer-not-known').attr('value', 'I didn\'t know that.');
+      $(page['query']).find('#query-answer-not-sure').prop('disabled', true);
+      $(page['query']).find('#query-answer-known').attr('value', 'I knew that!');
+      $(page['query']).find('#query-answer-not-known').attr('value', 'I didn\'t know that.');
       showQuerySolution();
       return;
     case QueryAnswerState.NotKnownClicked:
       queryCurrentAnswerState = QueryAnswerState.WaitToContinue;
       // no break here
     case QueryAnswerState.NotKnown:
-      $('#query-answer-not-known').prop('disabled', true);
-      $('#query-answer-not-sure').prop('disabled', true);
-      $('#query-answer-known').attr('value', 'Continue.');
-      $('#query-word-mark').html(Math.round(currentWord.getKnownAverage() * 100) + "%");
+      $(page['query']).find('#query-answer-not-known').prop('disabled', true);
+      $(page['query']).find('#query-answer-not-sure').prop('disabled', true);
+      $(page['query']).find('#query-answer-known').attr('value', 'Continue.');
+      $(page['query']).find('#query-word-mark').html(Math.round(currentWord.getKnownAverage() * 100) + "%");
       showQuerySolution();
       addQueryAnswer(currentWord, 0);
       tryAutoUpload();
@@ -685,9 +685,9 @@ function processQueryCurrentAnswerState() {
 }
 
 function showQuerySolution() {
-  $('#query-answer-buttons').show().html(currentWordCorrectAnswer);
-  $('#correct-answer').show().html(currentWordCorrectAnswer);
-  $('#query-answer').select();
+  $(page['query']).find('#query-answer-buttons').show().html(currentWordCorrectAnswer);
+  $(page['query']).find('#correct-answer').show().html(currentWordCorrectAnswer);
+  $(page['query']).find('#query-answer').select();
 }
 
 
@@ -698,22 +698,22 @@ function showQuerySolution() {
 // settings (algorithm, direction and type)
 
 // query algorithm
-$('#query-algorithm tr').on('click', function() {
-  $('#query-algorithm tr').removeClass('active');
+$(page['query']).find('#query-algorithm tr').on('click', function() {
+  $(page['query']).find('#query-algorithm tr').removeClass('active');
   $(this).addClass('active');
   queryChosenAlgorithm = parseInt($(this).data('algorithm'));
 });
 
 // query direction
-$('#query-direction tr').on('click', function() {
-  $('#query-direction tr').removeClass('active');
+$(page['query']).find('#query-direction tr').on('click', function() {
+  $(page['query']).find('#query-direction tr').removeClass('active');
   $(this).addClass('active');
   queryChosenDirection = parseInt($(this).data('direction'));
 });
 
 // query type
-$('#query-type tr').on('click', function() {
-  $('#query-type tr').removeClass('active');
+$(page['query']).find('#query-type tr').on('click', function() {
+  $(page['query']).find('#query-type tr').removeClass('active');
   $(this).addClass('active');
   setQueryType(parseInt($(this).data('type')));
 });
@@ -723,14 +723,14 @@ function setQueryType(queryType) {
     queryChosenType = queryType;
     
     if (queryType == QueryType.Buttons) {
-      $('#query-answer-table-cell-text-box').hide();
-      $('#query-answer-table-cell-buttons').show();
+      $(page['query']).find('#query-answer-table-cell-text-box').hide();
+      $(page['query']).find('#query-answer-table-cell-buttons').show();
       
     }
     else if (queryType == QueryType.TextBox) {
-      $('#query-answer-table-cell-buttons').hide();
-      $('#query-answer-table-cell-text-box').show();
-      $('#query-answer').focus();
+      $(page['query']).find('#query-answer-table-cell-buttons').hide();
+      $(page['query']).find('#query-answer-table-cell-text-box').show();
+      $(page['query']).find('#query-answer').focus();
     }
   }
 }
@@ -748,10 +748,10 @@ function tryAutoUpload() {
 }
 
 function autoUploadEnabled() {
-  return $('#query-results-auto-upload').is(':checked');
+  return $(page['query']).find('#query-results-auto-upload').is(':checked');
 }
 
-$('#query-results-auto-upload').on('click', function() {
+$(page['query']).find('#query-results-auto-upload').on('click', function() {
   if (autoUploadEnabled()) 
     uploadQueryResults();
 });
@@ -764,8 +764,8 @@ function updateQueryListLanguageInformation(languages) {
     languages = ["First language", "Second language"];
   }
 
-  $('span[data-value="first-language-information"]').html(languages[0]);
-  $('span[data-value="second-language-information"]').html(languages[1]);
+  $(page['query']).find('span[data-value="first-language-information"]').html(languages[0]);
+  $(page['query']).find('span[data-value="second-language-information"]').html(languages[1]);
 }
 
 

--- a/home/settings.js
+++ b/home/settings.js
@@ -26,30 +26,30 @@ $(window).on('page-settings', function(event, pageName, subPageName) {
 // menu
 function showSettingsPage(name) {
   shownSettingsSubPageName = name;
-  $('#settings-menu tr').removeClass('active');
-  $('#settings-menu tr[data-page=' + name + ']').addClass('active');
-  $('#settings-content > div').addClass('display-none');
-  $('#settings-content > div[data-page=' + name + ']').removeClass('display-none');
+  $(page['settings']).find('#settings-menu tr').removeClass('active');
+  $(page['settings']).find('#settings-menu tr[data-page=' + name + ']').addClass('active');
+  $(page['settings']).find('#settings-content > div').addClass('display-none');
+  $(page['settings']).find('#settings-content > div[data-page=' + name + ']').removeClass('display-none');
 }
 
-$('#settings-menu tr').on('click', function() {
+$(page['settings']).find('#settings-menu tr').on('click', function() {
   location.hash = '#/settings/' + $(this).data('page');
 });
 
 // change name
-$('#settings-name').on('submit', function(e) {
+$(page['settings']).find('#settings-name').on('submit', function(e) {
   e.preventDefault();
   
-  $('#settings-firstname, #settings-lastname').prop('disabled', true);
-  $('#settings-submit-button').prop('disabled', true).attr('value', 'Changing name...');
-  $('#settings-name-response').html('').addClass('display-none');
+  $(page['settings']).find('#settings-firstname, #settings-lastname').prop('disabled', true);
+  $(page['settings']).find('#settings-submit-button').prop('disabled', true).attr('value', 'Changing name...');
+  $(page['settings']).find('#settings-name-response').html('').addClass('display-none');
   
   // send request
   jQuery.ajax('server.php', {
     data: {
       action: 'set-name',
-      firstname: $('#settings-firstname').val(),
-      lastname: $('#settings-lastname').val()
+      firstname: $(page['settings']).find('#settings-firstname').val(),
+      lastname: $(page['settings']).find('#settings-lastname').val()
     },
     type: 'GET',
     error: function(jqXHR, textStatus, errorThrown) {
@@ -58,8 +58,8 @@ $('#settings-name').on('submit', function(e) {
   }).done(function(data) {
     data = handleAjaxResponse(data);
 
-    $('#settings-firstname, #settings-lastname').prop('disabled', false);
-    $('#settings-submit-button').prop('disabled', false).attr('value', 'Change name');
+    $(page['settings']).find('#settings-firstname, #settings-lastname').prop('disabled', false);
+    $(page['settings']).find('#settings-submit-button').prop('disabled', false).attr('value', 'Change name');
     
     var message = '';
     switch (data) {
@@ -73,26 +73,26 @@ $('#settings-name').on('submit', function(e) {
         message = 'An unknown error occured.';
         break;
     }
-    $('#settings-name-response').html(message).removeClass('display-none');
+    $(page['settings']).find('#settings-name-response').html(message).removeClass('display-none');
   });
 });
 
 
 
 // change password
-$('#settings-password').on('submit', function(e) {
+$(page['settings']).find('#settings-password').on('submit', function(e) {
   e.preventDefault();
   
-  $('#settings-password-old, #settings-password-new, #settings-password-new-confirm').prop('disabled', true);
-  $('#settings-password-button').prop('disabled', true).attr('value', 'Changing password...');
-  $('#settings-password-response').html('').addClass('display-none');
+  $(page['settings']).find('#settings-password-old, #settings-password-new, #settings-password-new-confirm').prop('disabled', true);
+  $(page['settings']).find('#settings-password-button').prop('disabled', true).attr('value', 'Changing password...');
+  $(page['settings']).find('#settings-password-response').html('').addClass('display-none');
   
   // send request
   jQuery.ajax('server.php?action=set-password', {
     data: {
-      password_old: $('#settings-password-old').val(),
-      password_new: $('#settings-password-new').val(),
-      password_new_confirm: $('#settings-password-new-confirm').val()
+      password_old: $(page['settings']).find('#settings-password-old').val(),
+      password_new: $(page['settings']).find('#settings-password-new').val(),
+      password_new_confirm: $(page['settings']).find('#settings-password-new-confirm').val()
     },
     type: 'POST',
     error: function(jqXHR, textStatus, errorThrown) {
@@ -101,8 +101,8 @@ $('#settings-password').on('submit', function(e) {
   }).done(function(data) {
     data = handleAjaxResponse(data);
 
-    $('#settings-password-old, #settings-password-new, #settings-password-new-confirm').prop('disabled', false).attr('value', '');
-    $('#settings-password-button').prop('disabled', false).attr('value', 'Change password');
+    $(page['settings']).find('#settings-password-old, #settings-password-new, #settings-password-new-confirm').prop('disabled', false).attr('value', '');
+    $(page['settings']).find('#settings-password-button').prop('disabled', false).attr('value', 'Change password');
     
     var message = '';
     switch (data) {
@@ -123,12 +123,12 @@ $('#settings-password').on('submit', function(e) {
         message = 'An unknown error occured.';
         break;
     }
-    $('#settings-password-response').html(message).removeClass('display-none');
+    $(page['settings']).find('#settings-password-response').html(message).removeClass('display-none');
   });
 });
 
 // change name
-$('#settings-delete-account-form').on('submit', function(e) {
+$(page['settings']).find('#settings-delete-account-form').on('submit', function(e) {
   e.preventDefault();
   
   var messageBox = new MessageBox();
@@ -137,14 +137,14 @@ $('#settings-delete-account-form').on('submit', function(e) {
   messageBox.setButtons(MessageBox.ButtonType.YesNoCancel);
   messageBox.setCallback(function(button) {
     if (button === 'Yes') {
-      $('#settings-delete-account-password').prop('disabled', true);
-      $('#settings-delete-account-button').prop('disabled', true).attr('value', 'Deleting account...');
-      $('#settings-delete-account-response').html('').addClass('display-none');
+      $(page['settings']).find('#settings-delete-account-password').prop('disabled', true);
+      $(page['settings']).find('#settings-delete-account-button').prop('disabled', true).attr('value', 'Deleting account...');
+      $(page['settings']).find('#settings-delete-account-response').html('').addClass('display-none');
       
       // send request
       jQuery.ajax('server.php?action=delete-account', {
         data: {
-          password: $('#settings-delete-account-password').val()
+          password: $(page['settings']).find('#settings-delete-account-password').val()
         },
         type: 'POST',
         error: function(jqXHR, textStatus, errorThrown) {
@@ -157,10 +157,10 @@ $('#settings-delete-account-form').on('submit', function(e) {
           window.location.replace('server.php?action=logout');
         } 
         else {
-          $('#settings-delete-account-password').prop('disabled', false).val('');
-          $('#settings-delete-account-button').prop('disabled', false).attr('value', 'Delete account');
+          $(page['settings']).find('#settings-delete-account-password').prop('disabled', false).val('');
+          $(page['settings']).find('#settings-delete-account-button').prop('disabled', false).attr('value', 'Delete account');
 
-          $('#settings-delete-account-response').html((data === 0) ? 'The password is not correct.' : 'An unknown error occured.').removeClass('display-none');
+          $(page['settings']).find('#settings-delete-account-response').html((data === 0) ? 'The password is not correct.' : 'An unknown error occured.').removeClass('display-none');
         }
       });
     }
@@ -196,6 +196,6 @@ function setAdsEnabled(adsEnabled) {
 }
 
 // checkbox event listener for changing ads enabled settings
-$('#enable-ads-checkbox').on('change', function() {
+$(page['settings']).find('#enable-ads-checkbox').on('change', function() {
   setAdsEnabled(this.checked);
 });

--- a/home/user.js
+++ b/home/user.js
@@ -25,19 +25,19 @@ function addUser(email, callback) {
 }
 
 // event listener for submit of form to add a new user
-$('#user-add-form').on('submit', function(e) {
+$(page['user']).find('#user-add-form').on('submit', function(e) {
   // dont visit action="..." page
   e.preventDefault();
 
   // disable button to avoid resubmission
-  $('#user-add-email').prop('disabled', true);
-  $('#user-add-button').prop('disabled', true).attr('value', 'Adding...');
+  $(page['user']).find('#user-add-email').prop('disabled', true);
+  $(page['user']).find('#user-add-button').prop('disabled', true).attr('value', 'Adding...');
 
   // call actual add user function and pass required information (email address of user to add)
-  addUser($('#user-add-email').val(), function(data) {
+  addUser($(page['user']).find('#user-add-email').val(), function(data) {
     // re-enable button and input field to allow adding another user
-    $('#user-add-email').prop('disabled', false).val('');
-    $('#user-add-button').prop('disabled', false).attr('value', 'Add user');
+    $(page['user']).find('#user-add-email').prop('disabled', false).val('');
+    $(page['user']).find('#user-add-button').prop('disabled', false).attr('value', 'Add user');
 
     // handle response string
     var responseString;
@@ -46,14 +46,14 @@ $('#user-add-form').on('submit', function(e) {
     else if (data === 1) responseString =  "User has been added.";
     else if (data === 2) responseString =  "You can not add yourself.";
     else responseString = "An unknown error occured.";
-    $('#user-add-message').html(responseString);
+    $(page['user']).find('#user-add-message').html(responseString);
   });
 });
 
 // removes a user by his id
 function removeUser(id) {
   // disable buton to avoid resubmission
-  $('#added-users-remove-' + id).prop('disabled', true).attr('value', 'Removing...');
+  $(page['user']).find('#added-users-remove-' + id).prop('disabled', true).attr('value', 'Removing...');
 
   jQuery.ajax('server.php', {
     data: {
@@ -68,12 +68,12 @@ function removeUser(id) {
     data = handleAjaxResponse(data);
 
     // remove row of the user who has just been deleted from the database
-    $('#added-users-row-' + id).remove();
+    $(page['user']).find('#added-users-row-' + id).remove();
 
     // update div
     // if no added users are left show the appropriate message
-    if ($('#people-you-have-added tr').length == 1) {
-      $('#people-you-have-added').html(noUsersAddedOutput);
+    if ($(page['user']).find('#people-you-have-added tr').length == 1) {
+      $(page['user']).find('#people-you-have-added').html(noUsersAddedOutput);
     }
 
     // refresh the other list without loading information
@@ -89,7 +89,7 @@ function removeUser(id) {
 function refreshListOfAddedUsers(showLoadingInformation) {
   // loading information
   if (showLoadingInformation)
-    $('#people-you-have-added').html(loading);
+    $(page['user']).find('#people-you-have-added').html(loading);
 
   jQuery.ajax('server.php', {
     data: {
@@ -117,7 +117,7 @@ function refreshListOfAddedUsers(showLoadingInformation) {
       output = '<table class="box-table button-right-column"><tr class="bold cursor-default"><td>Name</td><td>Email-Address</td><td></td></tr>' + output + '</table>';
     }
 
-    $('#people-you-have-added').html(output); // update the html element with the list
+    $(page['user']).find('#people-you-have-added').html(output); // update the html element with the list
   });
 }
 
@@ -125,7 +125,7 @@ function refreshListOfAddedUsers(showLoadingInformation) {
 function refreshListOfUsersWhoHaveAddedYou(showLoadingInformation) {
   // loading information
   if (showLoadingInformation)
-    $('#people-who-have-added-you').html(loading);
+    $(page['user']).find('#people-who-have-added-you').html(loading);
 
   jQuery.ajax('server.php', {
     data: {
@@ -155,10 +155,10 @@ function refreshListOfUsersWhoHaveAddedYou(showLoadingInformation) {
       output = '<table class="box-table button-right-column"><tr class="bold cursor-default"><td>Name</td><td>Email-Address</td><td></td></tr>' + output + '</table>';
     }
 
-    $('#people-who-have-added-you').html(output); // update DOM
+    $(page['user']).find('#people-who-have-added-you').html(output); // update DOM
 
     // add event listener for newly added buttons
-    $('#people-who-have-added-you input[type=button]').on('click', function() {
+    $(page['user']).find('#people-who-have-added-you input[type=button]').on('click', function() {
       // buttons function is adding users
       var $button = $(this);
       $button.prop('disabled', true).val('Adding...'); // disable button and change value

--- a/home/word-lists.js
+++ b/home/word-lists.js
@@ -57,26 +57,26 @@ function addWordList(name, callback) {
 }
 
 // event listener for form which adds new word lists
-$('#word-list-add-form').on('submit', function(e) {
+$(page['word-lists']).find('#word-list-add-form').on('submit', function(e) {
   // dont visit action="..." page
   e.preventDefault();
 
   // disable button and text box to prevent resubmission
-  $('#word-list-add-name').prop('disabled', true);
-  $('#word-list-add-button').prop('disabled', true).attr('value', 'Creating list...');
+  $(page['word-lists']).find('#word-list-add-name').prop('disabled', true);
+  $(page['word-lists']).find('#word-list-add-button').prop('disabled', true).attr('value', 'Creating list...');
 
   // call the server contacting function
-  addWordList($('#word-list-add-name').val(), function(data) {
+  addWordList($(page['word-lists']).find('#word-list-add-name').val(), function(data) {
     // finished callback
     // re-enable the button and the text box
-    $('#word-list-add-name').prop('disabled', false).val('');
-    $('#word-list-add-button').prop('disabled', false).attr('value', 'Create list');
+    $(page['word-lists']).find('#word-list-add-name').prop('disabled', false).val('');
+    $(page['word-lists']).find('#word-list-add-button').prop('disabled', false).attr('value', 'Create list');
 
     refreshListOfWordLists(false, function() {
       // handle buttons and background colors indicating which list is currently shown
       setAllListRowsAsNotActive();
       // highlight the lists row by adding active class and hide button to view the list
-      $('#list-of-word-lists tr[data-list-id=' + data.id + ']').addClass('active').find('input[type=button]').first().hide();
+      $(page['word-lists']).find('#list-of-word-lists tr[data-list-id=' + data.id + ']').addClass('active').find('input[type=button]').first().hide();
     }); // refresh the list of word lists without loading information
 
     // load the word list which has just been added
@@ -92,7 +92,7 @@ function refreshListOfWordLists(showLoadingInformation, callback, firstCall) {
 
   // loading information
   if (showLoadingInformation)
-    $('#list-of-word-lists').html(loading);
+    $(page['word-lists']).find('#list-of-word-lists').html(loading);
 
   // reset all table row highlights and hidden buttons indicating which list is selected
   showNoListSelectedInfo(!firstCall);
@@ -125,10 +125,10 @@ function refreshListOfWordLists(showLoadingInformation, callback, firstCall) {
         output = '<table class="box-table cursor-pointer"></tr>' + output + '</table>';
       }
 
-      $('#list-of-word-lists').html(output); // update DOM with list of word lists
+      $(page['word-lists']).find('#list-of-word-lists').html(output); // update DOM with list of word lists
 
       // add event listeners for rows which have just been added
-      $('#list-of-word-lists tr').on('click', function() {
+      $(page['word-lists']).find('#list-of-word-lists tr').on('click', function() {
         window.location.hash = '#/word-lists/' + $(this).data('list-id');
       });
     })
@@ -138,7 +138,7 @@ function refreshListOfWordLists(showLoadingInformation, callback, firstCall) {
 
 // handle buttons and background colors indicating which list is currently shown
 function setAllListRowsAsNotActive() {
-  $('#list-of-shared-word-lists tr, #list-of-word-lists tr').removeClass('active'); // un-highlights all table rows
+  $(page['word-lists']).find('#list-of-shared-word-lists tr, #list-of-word-lists tr').removeClass('active'); // un-highlights all table rows
 }
 
 
@@ -147,7 +147,7 @@ function refreshListOfSharedWordLists(showLoadingInformation, firstCall) {
   if (firstCall === undefined) firstCall = false;
   
   if (showLoadingInformation)
-    $('#list-of-shared-word-lists').html(loading);
+    $(page['word-lists']).find('#list-of-shared-word-lists').html(loading);
 
   showNoListSelectedInfo(!firstCall);
 
@@ -179,10 +179,10 @@ function refreshListOfSharedWordLists(showLoadingInformation, firstCall) {
       else {
         output = '<table class="box-table cursor-pointer">' + output + '</table>';
       }
-      $('#list-of-shared-word-lists').html(output); // update the DOM
+      $(page['word-lists']).find('#list-of-shared-word-lists').html(output); // update the DOM
 
       // add event listeners for rows inside the list
-      $('#list-of-shared-word-lists tr').on('click', function() {
+      $(page['word-lists']).find('#list-of-shared-word-lists tr').on('click', function() {
         window.location.hash = '#/word-lists/' + $(this).data('list-id');
       });
     })
@@ -199,12 +199,12 @@ function showNoListSelectedInfo(updateHash) {
     window.location.hash = '#/word-lists';
   }
 
-  $('#word-list-info .box-head > div').html("Word lists");
-  $('#word-list-info .box-body').html('<p class="spacer-30">Create or select a word list to get started.</p>');
-  $('#word-list-info-words').hide();
-  $('#word-list-title').hide();
-  $('#word-list-sharing').hide();
-  $('#word-list-label').hide();
+  $(page['word-lists']).find('#word-list-info .box-head > div').html("Word lists");
+  $(page['word-lists']).find('#word-list-info .box-body').html('<p class="spacer-30">Create or select a word list to get started.</p>');
+  $(page['word-lists']).find('#word-list-info-words').hide();
+  $(page['word-lists']).find('#word-list-title').hide();
+  $(page['word-lists']).find('#word-list-sharing').hide();
+  $(page['word-lists']).find('#word-list-label').hide();
 }
 
 
@@ -213,14 +213,14 @@ function showNoListSelectedInfo(updateHash) {
 function loadWordList(id, showLoadingInformation, showWordListPage) {
   // show loading information
   if (showLoadingInformation) {
-    $('#word-list-info .box-head > div').html("Loading...");
-    $('#word-list-info .box-body').html(loading);
+    $(page['word-lists']).find('#word-list-info .box-head > div').html("Loading...");
+    $(page['word-lists']).find('#word-list-info .box-body').html(loading);
 
     // hide all divs which will later show things like words, sharings, labels and the list name while the list loads
-    $('#word-list-info-words').hide();
-    $('#word-list-sharing').hide();
-    $('#word-list-label').hide();
-    $('#word-list-title').hide();
+    $(page['word-lists']).find('#word-list-info-words').hide();
+    $(page['word-lists']).find('#word-list-sharing').hide();
+    $(page['word-lists']).find('#word-list-label').hide();
+    $(page['word-lists']).find('#word-list-title').hide();
   }
   
   // a call of this method can force to show the page "word lists" with the parameter showWordListPage
@@ -233,7 +233,7 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
   // handle buttons and background colors indicating which list is currently shown
   setAllListRowsAsNotActive();
   // highlight the lists row by adding active class and hide button to view the list
-  $('#list-of-word-lists tr[data-list-id=' + id + '], #list-of-shared-word-lists tr[data-list-id=' + id + ']').addClass('active').find('input[type=button]').first().hide();
+  $(page['word-lists']).find('#list-of-word-lists tr[data-list-id=' + id + '], #list-of-shared-word-lists tr[data-list-id=' + id + ']').addClass('active').find('input[type=button]').first().hide();
 
   shownListId = id;
 
@@ -271,8 +271,8 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
       if (!shownListData.language2) shownListData.language2 = "Second language";
 
       // info box head and list name box
-      $('#word-list-title .box-head').html(shownListData.name);
-      $('#word-list-info .box-head > div').html("General");
+      $(page['word-lists']).find('#word-list-title .box-head').html(shownListData.name);
+      $(page['word-lists']).find('#word-list-info .box-head > div').html("General");
 
       // info box body
       // add content depending on the users permissions (sharing and editing)
@@ -307,27 +307,27 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
       // add export button
       //wordListInfoBoxBody += '<input id="export-list" type="button" value="Export..." onclick="exportList()"/>';
 
-      $('#word-list-info .box-body').html(wordListInfoBoxBody); // update DOM
+      $(page['word-lists']).find('#word-list-info .box-body').html(wordListInfoBoxBody); // update DOM
 
 
-      $('#words-add-language1').attr('placeholder', shownListData.language1);
-      $('#words-add-language2').attr('placeholder', shownListData.language2);
+      $(page['word-lists']).find('#words-add-language1').attr('placeholder', shownListData.language1);
+      $(page['word-lists']).find('#words-add-language2').attr('placeholder', shownListData.language2);
 
       // sharing box
       if (allowSharing) {
         // refresh sharing box with loading information
         refreshListSharings(true, shownListData.id);
-        $('#word-list-sharing').show();
+        $(page['word-lists']).find('#word-list-sharing').show();
       }
       else {
-        $('#word-list-sharing').hide();
+        $(page['word-lists']).find('#word-list-sharing').hide();
       }
 
       // list of words
-      $('#shown-word-list-words-count').html(shownListData.words.length); // update word count
+      $(page['word-lists']).find('#shown-word-list-words-count').html(shownListData.words.length); // update word count
       
       if (shownListData.words.length === 0) { // no words added yet
-        $('#words-in-list').html((allowEdit)?noWordsInList:noWordsInListDisallowEdit);
+        $(page['word-lists']).find('#words-in-list').html((allowEdit)?noWordsInList:noWordsInListDisallowEdit);
       }
       else {
         // add words of the list to the DOM
@@ -336,12 +336,12 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
           wordListHTML += getTableRowOfWord(shownListData.words[i].id, shownListData.words[i].language1, shownListData.words[i].language2, allowEdit);
         }
         wordListHTML = getTableOfWordList(wordListHTML, allowEdit, shownListData.language1, shownListData.language2);
-        $('#words-in-list').html(wordListHTML);
+        $(page['word-lists']).find('#words-in-list').html(wordListHTML);
       }
 
       // events
       // delete word list
-      $('#delete-shown-word-list').on('click', function() {
+      $(page['word-lists']).find('#delete-shown-word-list').on('click', function() {
         // show message box
         var messageBox = new MessageBox();
         messageBox.setTitle('Delete word list');
@@ -361,7 +361,7 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
       });
 
       // hide word list (stop sharing)
-      $('#hide-shown-word-list').on('click', function() {
+      $(page['word-lists']).find('#hide-shown-word-list').on('click', function() {
         // show message box
         var messageBox = new MessageBox();
         messageBox.setTitle('Hide word list');
@@ -370,14 +370,14 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
         messageBox.setCallback(function(button) {
           if (button === 'Yes') {
             $(this).prop('disabled', true).attr('value', 'Hiding list...'); // disable button
-            var sharingId = $('tr[data-list-id=' + shownListId + ']').data('sharing-id');
+            var sharingId = $(page['word-lists']).find('tr[data-list-id=' + shownListId + ']').data('sharing-id');
             // send server request to hide the shared list
             setSharingPermissionsBySharingId(sharingId, 0, function() {
-              $('#list-of-shared-word-lists-row-' + sharingId).remove();
+              $(page['word-lists']).find('#list-of-shared-word-lists-row-' + sharingId).remove();
 
               // still rows left?
-              if ($('#list-of-shared-word-lists tr').length == 1) {
-                $('#list-of-shared-word-lists').html(noSharedWordListOutput); // show appropriate message if there are no lists to display
+              if ($(page['word-lists']).find('#list-of-shared-word-lists tr').length == 1) {
+                $(page['word-lists']).find('#list-of-shared-word-lists').html(noSharedWordListOutput); // show appropriate message if there are no lists to display
               }
 
               // because the shown list has just been removed update the screen to show the appropriate message
@@ -389,11 +389,11 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
       });
 
       // rename form
-      $('#rename-list-form').on('submit', function(e) {
+      $(page['word-lists']).find('#rename-list-form').on('submit', function(e) {
         e.preventDefault();
 
         // disable button and inputs
-        var $nameInput = $('#rename-list-name'), $submitButton = $('#rename-list-button');
+        var $nameInput = $(page['word-lists']).find('#rename-list-name'), $submitButton = $(page['word-lists']).find('#rename-list-button');
         $nameInput.prop('disabled', true);
         $submitButton.prop('disabled', true).attr('value', 'Renaming...');
 
@@ -408,17 +408,17 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
           shownListData.name = newListName;
 
           // update the information where the list name was shown
-          $('#word-list-title .box-head').html(newListName); // on top of the page
-          $('#list-of-word-lists-row-' + shownListId).children().first().html(newListName); // inside the list of word lists
+          $(page['word-lists']).find('#word-list-title .box-head').html(newListName); // on top of the page
+          $(page['word-lists']).find('#list-of-word-lists-row-' + shownListId).children().first().html(newListName); // inside the list of word lists
         });
       });
 
       // change language form event listener
-      $('#change-language-form').on('submit', function(e) {
+      $(page['word-lists']).find('#change-language-form').on('submit', function(e) {
         e.preventDefault();
 
         // disable inputs and button
-        var $lang1Input = $('#word-list-language1'), $lang2Input = $('#word-list-language2'), $submitButton = $('#word-list-languages-button');
+        var $lang1Input = $(page['word-lists']).find('#word-list-language1'), $lang2Input = $(page['word-lists']).find('#word-list-language2'), $submitButton = $(page['word-lists']).find('#word-list-languages-button');
         $lang1Input.prop('disabled', true);
         $lang2Input.prop('disabled', true);
         $submitButton.prop('disabled', true).attr('value', 'Editing languages...');
@@ -440,28 +440,28 @@ function loadWordList(id, showLoadingInformation, showWordListPage) {
 
           // update the information where the list languages were shown
           // placeholder of word add form
-          $('#words-add-language1').attr('placeholder', lang1);
-          $('#words-add-language2').attr('placeholder', lang2);
+          $(page['word-lists']).find('#words-add-language1').attr('placeholder', lang1);
+          $(page['word-lists']).find('#words-add-language2').attr('placeholder', lang2);
           // word list table head
-          $('#word-list-table').find('td').eq(0).html(lang1);
-          $('#word-list-table').find('td').eq(1).html(lang2);
+          $(page['word-lists']).find('#word-list-table').find('td').eq(0).html(lang1);
+          $(page['word-lists']).find('#word-list-table').find('td').eq(1).html(lang2);
         });
       });
 
 
 
       // show divs which have been updated above
-      $('#word-list-title').show();
-      $('#word-list-info-words').show();
+      $(page['word-lists']).find('#word-list-title').show();
+      $(page['word-lists']).find('#word-list-info-words').show();
 
       if (allowEdit)
-        $('#words-add').show();
+        $(page['word-lists']).find('#words-add').show();
       else
-        $('#words-add').hide();
+        $(page['word-lists']).find('#words-add').hide();
 
       // update label list with loading information
       getLabelList(true);
-      $('#word-list-label').show();
+      $(page['word-lists']).find('#word-list-label').show();
     })
   );
 }
@@ -501,7 +501,7 @@ function editSaveWord(event, id) {
   event.preventDefault(); // stop form submission
 
   // jQuery vars of the important elements
-  var $row = $('#word-row-' + id); // the HTML row (<tr>)
+  var $row = $(page['word-lists']).find('#word-row-' + id); // the HTML row (<tr>)
   var $editSaveButton = $row.find('input[type=submit]'); // the button (<input type="button"/>)
   var $cell1 = $row.children().eq(0), $cell2 = $row.children().eq(1); // the first cell in the words table row (<td>)
 
@@ -518,7 +518,7 @@ function editSaveWord(event, id) {
   // save button
   else {
     // disable the form elements
-    var $lang1Input = $('#word-edit-input-language1-' + id), $lang2Input = $('#word-edit-input-language2-' + id);
+    var $lang1Input = $(page['word-lists']).find('#word-edit-input-language1-' + id), $lang2Input = $(page['word-lists']).find('#word-edit-input-language2-' + id);
     $lang1Input.prop('disabled', true);
     $lang2Input.prop('disabled', true);
     $editSaveButton.prop('disabled', true).attr('value', 'Saving...');
@@ -581,7 +581,7 @@ function removeWord(id) {
   var listId = shownListId;
   
   // update button
-  var $row = $('#word-row-' + id);
+  var $row = $(page['word-lists']).find('#word-row-' + id);
   var $removeButton = $row.find('* input[type=button]');
   $removeButton.prop('disabled', true).attr('value', 'Removing...');
 
@@ -607,15 +607,15 @@ function removeWord(id) {
       }
     }
     
-    $('#shown-word-list-words-count').html(shownListData.words.length); // update word count
+    $(page['word-lists']).find('#shown-word-list-words-count').html(shownListData.words.length); // update word count
 
 
     // remove the row of the removed word from the DOM
     $row.remove();
 
     // show special message if no word is left
-    if ($('#word-list-table tr').length == 1) {
-      $('#word-list-table').html(noWordsInList);
+    if ($(page['word-lists']).find('#word-list-table tr').length == 1) {
+      $(page['word-lists']).find('#word-list-table').html(noWordsInList);
     }
   });
 }
@@ -638,11 +638,11 @@ function deleteWordList(id, callback) {
     refreshRecentlyUsed(false);
 
     // remove the word list row from the DOM
-    $('#list-of-word-lists-row-' + id).remove();
+    $(page['word-lists']).find('#list-of-word-lists-row-' + id).remove();
 
     // no list table row anymore (except from the th)
-    if ($('#list-of-word-lists tr').length == 1) {
-      $('#list-of-word-lists').html(noWordListOutput);
+    if ($(page['word-lists']).find('#list-of-word-lists tr').length == 1) {
+      $(page['word-lists']).find('#list-of-word-lists').html(noWordListOutput);
     }
 
 
@@ -652,15 +652,15 @@ function deleteWordList(id, callback) {
 
 
 // add new word form submit event listener
-$('#words-add-form').on('submit', function(e) {
+$(page['word-lists']).find('#words-add-form').on('submit', function(e) {
   e.preventDefault();
 
   // read input fields
-  var lang1 = $('#words-add-language1').val(), lang2 = $('#words-add-language2').val();
+  var lang1 = $(page['word-lists']).find('#words-add-language1').val(), lang2 = $(page['word-lists']).find('#words-add-language2').val();
 
   // clear input fields and focus the first one to allow the user to enter the next word immediately
-  $('#words-add-language1').val('').focus();
-  $('#words-add-language2').val('');
+  $(page['word-lists']).find('#words-add-language1').val('').focus();
+  $(page['word-lists']).find('#words-add-language2').val('');
 
   // send word to the server
   addWord(lang1, lang2, true);
@@ -694,16 +694,16 @@ function addWord(lang1, lang2, allowEdit) {
       answers: null
     });
 
-    $('#shown-word-list-words-count').html(shownListData.words.length); // update word count
+    $(page['word-lists']).find('#shown-word-list-words-count').html(shownListData.words.length); // update word count
 
     
-    if ($('#word-list-table').length === 0) { // no words added yet
+    if ($(page['word-lists']).find('#word-list-table').length === 0) { // no words added yet
       var wordListHTML = getTableOfWordList("", allowEdit, shownListData.language1, shownListData.language2);
-      $('#words-in-list').html(wordListHTML);
+      $(page['word-lists']).find('#words-in-list').html(wordListHTML);
     }
 
     // add word row to the list of words
-    $('#word-list-table tr:nth-child(1)').after(getTableRowOfWord(data, lang1, lang2, allowEdit));
+    $(page['word-lists']).find('#word-list-table tr:nth-child(1)').after(getTableRowOfWord(data, lang1, lang2, allowEdit));
 
     // new Toast('The word "' + lang1 + '" - "' + lang2 + '" has been added successfully.');
   });
@@ -718,9 +718,9 @@ function refreshListSharings(showLoadingInformation, wordListId) {
     wordListId = shownListId;
 
   // show loading information
-  $('#word-list-sharing').show();
+  $(page['word-lists']).find('#word-list-sharing').show();
   if (showLoadingInformation) {
-    $('#list-sharings').html(loading);
+    $(page['word-lists']).find('#list-sharings').html(loading);
   }
 
 
@@ -739,7 +739,7 @@ function refreshListSharings(showLoadingInformation, wordListId) {
       data = handleAjaxResponse(data);
 
       if (data.length === 0) { // list not shared yet
-        $('#list-sharings').html(listNotShared); // show appropriate message
+        $(page['word-lists']).find('#list-sharings').html(listNotShared); // show appropriate message
       }
       else { // list shared with at least one user
         var output = "";
@@ -753,11 +753,11 @@ function refreshListSharings(showLoadingInformation, wordListId) {
         // add table to output string
         output = '<table class="box-table button-right-column"><tr class="bold cursor-default"><td>Name</td><td>Permissions</td><td></td></tr>' + output + '</table>';
 
-        $('#list-sharings').html(output); // display the output string
+        $(page['word-lists']).find('#list-sharings').html(output); // display the output string
 
         // event listeners for the buttons just added
         // stop sharing button
-        $('#list-sharings input[type=button]').on('click', function() {
+        $(page['word-lists']).find('#list-sharings input[type=button]').on('click', function() {
 
           var $button = $(this);
           $button.prop('disabled', true).attr('value', 'Stopping sharing...'); // change button value and disable button
@@ -766,11 +766,11 @@ function refreshListSharings(showLoadingInformation, wordListId) {
           setSharingPermissionsBySharingId($button.data('sharing-id'), 0, function() {
 
             // remove the row from the table
-            $('#list-shared-with-row-' + $button.data('sharing-id')).remove();
+            $(page['word-lists']).find('#list-shared-with-row-' + $button.data('sharing-id')).remove();
 
             // still rows left?
-            if ($('#list-sharings tr').length == 1) {
-              $('#list-sharings').html(listNotShared);
+            if ($(page['word-lists']).find('#list-sharings tr').length == 1) {
+              $(page['word-lists']).find('#list-sharings').html(listNotShared);
             }
           });
         });
@@ -781,24 +781,24 @@ function refreshListSharings(showLoadingInformation, wordListId) {
 
 
 // share list form submit event listener
-$('#share-list-form').on('submit', function(e) {
+$(page['word-lists']).find('#share-list-form').on('submit', function(e) {
   // dont visit action="..." page
   e.preventDefault();
 
   // disable form elements
-  $('#share-list-other-user-email').prop('disabled', true);
-  $('#share-list-permissions').prop('disabled', true);
-  $('#share-list-submit').prop('disabled', true).attr('value', 'Sharing...');
+  $(page['word-lists']).find('#share-list-other-user-email').prop('disabled', true);
+  $(page['word-lists']).find('#share-list-permissions').prop('disabled', true);
+  $(page['word-lists']).find('#share-list-submit').prop('disabled', true).attr('value', 'Sharing...');
 
   // send message to server
-  var email = $('#share-list-other-user-email').val();
-  setSharingPermissions(shownListId, email, $('#share-list-permissions').val(), function(data) {
+  var email = $(page['word-lists']).find('#share-list-other-user-email').val();
+  setSharingPermissions(shownListId, email, $(page['word-lists']).find('#share-list-permissions').val(), function(data) {
     // finished callback
 
     // re-enable the form elements
-    $('#share-list-other-user-email').prop('disabled', false).val('');
-    $('#share-list-permissions').prop('disabled', false);
-    $('#share-list-submit').prop('disabled', false).attr('value', 'Share');
+    $(page['word-lists']).find('#share-list-other-user-email').prop('disabled', false).val('');
+    $(page['word-lists']).find('#share-list-permissions').prop('disabled', false);
+    $(page['word-lists']).find('#share-list-submit').prop('disabled', false).attr('value', 'Share');
 
     // refresh the list of sharings without loading information
     refreshListSharings(false, shownListId);
@@ -871,7 +871,7 @@ function setSharingPermissions(listId, email, permissions, callback) {
 // get label list of user
 function getLabelList(showLoadingInformation) {
   if (showLoadingInformation)
-    $('#list-labels-list').html(loading);
+    $(page['word-lists']).find('#list-labels-list').html(loading);
 
   // send request
   jQuery.ajax('server.php', {
@@ -889,23 +889,23 @@ function getLabelList(showLoadingInformation) {
 
 
 
-    $('#list-labels-list').html(getEditableHtmlTableOfLabels(labels)); // update DOM
+    $(page['word-lists']).find('#list-labels-list').html(getEditableHtmlTableOfLabels(labels)); // update DOM
     
     
     // open small menu for single label event trigger
-    $('#list-labels-list img.small-menu-open-image').on('click', function(e) {
-      $('.small-menu').addClass('display-none');
+    $(page['word-lists']).find('#list-labels-list img.small-menu-open-image').on('click', function(e) {
+      $(page['word-lists']).find('.small-menu').addClass('display-none');
       $(this).next().removeClass('display-none');
       e.stopPropagation(); // prevent triggering click event on body which listens for click to close the popup
     });
-    $('#list-labels-list .small-menu input').on('click', function(e) {
+    $(page['word-lists']).find('#list-labels-list .small-menu input').on('click', function(e) {
       $(this).parents('.small-menu').addClass('display-none');
     });
-    $('#list-labels-list .small-menu').on('click', function(e) { e.stopPropagation(); }); // prevent triggering click event on body which listens for click to close the popup
+    $(page['word-lists']).find('#list-labels-list .small-menu').on('click', function(e) { e.stopPropagation(); }); // prevent triggering click event on body which listens for click to close the popup
 
     // just added checkboxes event listener
     // the checkboxes allow the user to attach the list to a label by checking the checkbox
-    $('#list-labels-list input[type=checkbox]').click( function(){
+    $(page['word-lists']).find('#list-labels-list input[type=checkbox]').click( function(){
       // read label id from checkbox data tag
       var labelId = $(this).data('label-id');
 
@@ -927,7 +927,7 @@ function getLabelList(showLoadingInformation) {
 
 
     // add new label form event listener
-    $('.label-add-form').on('submit', function(e) {
+    $(page['word-lists']).find('.label-add-form').on('submit', function(e) {
       e.preventDefault();
 
       // disable form elements
@@ -950,7 +950,7 @@ function getLabelList(showLoadingInformation) {
     });
 
     // remove label form submit event listener
-    $('.label-remove-form').on('submit', function(e) {
+    $(page['word-lists']).find('.label-remove-form').on('submit', function(e) {
       e.preventDefault();
 
       // update form children
@@ -974,19 +974,19 @@ function getLabelList(showLoadingInformation) {
     });
 
     // add sub label event listener
-    $('.label-add-sub-label').on('click', function() {
+    $(page['word-lists']).find('.label-add-sub-label').on('click', function() {
       // show the "add sub label form" which is hidden in the following <tr>
       $(this).hide().parent().parent().parent().next().show().children().find('input[type=text]').first().focus();
     });
 
     // label rename form event listener
-    $('.label-rename-form').on('submit', function(e) {
+    $(page['word-lists']).find('.label-rename-form').on('submit', function(e) {
       e.preventDefault();
 
       // get label id from data tag of the form
       var labelId = $(this).data('label-id');
-      var $button = $('#label-rename-button-' + labelId);
-      var $firstCell = $('#label-rename-table-cell-' + labelId);
+      var $button = $(page['word-lists']).find('#label-rename-button-' + labelId);
+      var $firstCell = $(page['word-lists']).find('#label-rename-table-cell-' + labelId);
 
       // edit name
       if ($button.data('action') == 'rename-edit') {
@@ -1018,7 +1018,7 @@ function getLabelList(showLoadingInformation) {
 
 
     // expand single labels
-    $('#list-labels-list .small-exp-col-icon').on('click', function() {
+    $(page['word-lists']).find('#list-labels-list .small-exp-col-icon').on('click', function() {
       var $this = $(this);
       var expand = ($this.data('state') == 'collapsed');
 
@@ -1057,7 +1057,7 @@ function getLabelList(showLoadingInformation) {
 
 // close small menu for single label event trigger
 $('body').on('click', function() {
-  $('.small-menu').addClass('display-none');
+  $(page['word-lists']).find('.small-menu').addClass('display-none');
 }); 
 
 

--- a/single-page-application.js
+++ b/single-page-application.js
@@ -13,18 +13,18 @@ var shownPageName, shownHashName,
       'legal-info': 'Legal info'
     };
 
-var pageElements = {}, pageElementsParent = document.getElementById('main');
+var page = {}, pageElementsParent = document.getElementById('main');
 (function() {
   var jQueryPageElement = $('#main').children('div');
   for (var i = 0;  i < jQueryPageElement.length; i++) {
     var id = jQueryPageElement.eq(i).attr('id');
     if (id !== undefined && id.substring(0, 8) === 'content-') {
-      pageElements[id.substring(8)] = jQueryPageElement[i];
+      page[id.substring(8)] = jQueryPageElement[i];
     }
   }
 
-  for (var page in pageElements) {
-    pageElementsParent.removeChild(pageElements[page]);
+  for (var singlePage in page) {
+    pageElementsParent.removeChild(page[singlePage]);
   }
 })();
 
@@ -39,7 +39,7 @@ var updatePageContent = function () {
   var pageName = (firstPart.length === 0) ? "home" : firstPart;
 
 
-  if (pageElements[pageName] === undefined) { // given page doesn't exist
+  if (page[pageName] === undefined) { // given page doesn't exist
     // forward to home page
     pageName = "home";
   }
@@ -59,7 +59,7 @@ var updatePageContent = function () {
   if (shownPageName === pageName) return;
   
   if (shownPageName !== undefined) {
-    pageElementsParent.removeChild(pageElements[shownPageName]);
+    pageElementsParent.removeChild(page[shownPageName]);
   }
   
   shownPageName = pageName;
@@ -67,7 +67,7 @@ var updatePageContent = function () {
   
   // mark nav element as visisted (class active)
   $('.nav_' + pageName).addClass('visited');
-  pageElementsParent.insertBefore(pageElements[pageName], pageElementsParent.firstChild); // show the div containing the requested page
+  pageElementsParent.insertBefore(page[pageName], pageElementsParent.firstChild); // show the div containing the requested page
   window.scrollTo(0, 0); // scroll to the top
   
   $(((typeof adsEnabled !== 'undefined' && adsEnabled) ? '.advertisement-bottom, ' : '') + '#footer-wrapper, #cookie-header').show();


### PR DESCRIPTION
$(‘#blabla’) is now like $(page[‘page-name-of-blabla’]).find(‘#blabla’)

This has the advantage that not every page (“Home”, “Word lists”, “Test”, …) is rendered even if not displayed (e.g. when the user
wants to see the page “Word lists” the page “Settings” doesn’t need to
be rendered).
